### PR TITLE
[COMPUTE-495] Add logging around Route53 ResourceRecord counts per batch

### DIFF
--- a/provider/aws.go
+++ b/provider/aws.go
@@ -333,6 +333,8 @@ func (p *AWSProvider) submitChanges(changes []*route53.Change) error {
 			if nLogicalRecordsInBatch >= p.batchChangeSize || nRecordsAsViewedByRoute53LimitsInBatch >= route53ResourceRecordsPerBatchLimit {
 				log.Errorf("Attempting to update %d ResourceRecords across %d change sets, with a total of %d changes as measured by Route53! Route53 limits Changes to %d ResourceRecords, so this will almost certainly fail!",
 					nLogicalRecordsInBatch, len(b), nRecordsAsViewedByRoute53LimitsInBatch, route53ResourceRecordsPerBatchLimit)
+			} else {
+				log.Infof("Attempting to update %d ResourceRecords across %d change sets, with a total of %d changes as measured by Route53", nLogicalRecordsInBatch, len(b), nRecordsAsViewedByRoute53LimitsInBatch)
 			}
 
 			if !p.dryRun {

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -37,6 +37,8 @@ const (
 	// provider specific key that designates whether an AWS ALIAS record has the EvaluateTargetHealth
 	// field set to true.
 	providerSpecificEvaluateTargetHealth = "aws/evaluate-target-health"
+
+	route53ResourceRecordsPerBatchLimit = 1000
 )
 
 var (
@@ -308,8 +310,29 @@ func (p *AWSProvider) submitChanges(changes []*route53.Change) error {
 		batchCs := batchChangeSet(cs, p.batchChangeSize)
 
 		for i, b := range batchCs {
+			nLogicalRecordsInBatch := 0
+			nRecordsAsViewedByRoute53LimitsInBatch := 0
 			for _, c := range b {
-				log.Infof("Desired change: %s %s %s", *c.Action, *c.ResourceRecordSet.Name, *c.ResourceRecordSet.Type)
+				multiplier := 1
+				if *c.Action == route53.ChangeActionUpsert {
+					// upserted records count as both create+delete
+					multiplier = 2
+				}
+				nLogicalRecordsInChange := len(c.ResourceRecordSet.ResourceRecords)
+				nRecordsAsViewedByRoute53LimitsInChange := nLogicalRecordsInChange * multiplier
+				if nRecordsAsViewedByRoute53LimitsInChange > 200 {
+					log.Warnf("Desired change: %s %s %s has %d ResourceRecords, which is pretty spicy. Route53 limits Changes to %d ResourceRecords, so you may consider limiting the number of records?",
+						*c.Action, *c.ResourceRecordSet.Name, *c.ResourceRecordSet.Type, nLogicalRecordsInChange, nRecordsAsViewedByRoute53LimitsInChange, route53ResourceRecordsPerBatchLimit)
+				} else {
+					log.Infof("Desired change: %s %s %s (%d records, %d records in route53.Change)", *c.Action, *c.ResourceRecordSet.Name, *c.ResourceRecordSet.Type, nLogicalRecordsInChange, nRecordsAsViewedByRoute53LimitsInChange)
+				}
+				nLogicalRecordsInBatch += nLogicalRecordsInChange
+				nRecordsAsViewedByRoute53LimitsInBatch += nRecordsAsViewedByRoute53LimitsInChange
+			}
+
+			if nLogicalRecordsInBatch >= p.batchChangeSize || nRecordsAsViewedByRoute53LimitsInBatch >= route53ResourceRecordsPerBatchLimit {
+				log.Errorf("Attempting to update %d ResourceRecords across %d change sets, with a total of %d changes as measured by Route53! Route53 limits Changes to %d ResourceRecords, so this will almost certainly fail!",
+					nLogicalRecordsInBatch, len(b), nRecordsAsViewedByRoute53LimitsInBatch, route53ResourceRecordsPerBatchLimit)
 			}
 
 			if !p.dryRun {


### PR DESCRIPTION
**Description**

* https://datadoghq.atlassian.net/browse/COMPUTE-495
* AWS Support Ticket 7337065631

Adds improved logging to detect change batches where the number of records (as counted by Route53) exceeds a reasonable count (warn over 200), and logs a summary of the total ResourceRecords in each batched change, both logically and as counted by the Route53 API (UPSERTS are double counted). This issue causes Route53 to 400 our updates when more than 1000 ResourceRecords are changed in 1 update interval, creating Incident #5510.

Error observed:
```
InvalidChangeBatch: [Number of records limit of 1000 exceeded.]
```

## 🤔🤔

Unit tests failed when I cut my branch (with no changes), and I can only get it to build in docker, not on my mac. I wont spend much time trying to repair this, but its an action item for the future to get this build happier.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated

cc @lbernail @EricMountain 
