### PR TITLE
COMPUTE-495 Truncate endpoint targets to 400 for Route53

### DIFF
--- a/provider/aws.go
+++ b/provider/aws.go
@@ -322,7 +322,7 @@ func (p *AWSProvider) submitChanges(changes []*route53.Change) error {
 				nRecordsAsViewedByRoute53LimitsInChange := nLogicalRecordsInChange * multiplier
 				if nRecordsAsViewedByRoute53LimitsInChange > 200 {
 					log.Warnf("Desired change: %s %s %s has %d ResourceRecords, which is pretty spicy. Route53 limits Changes to %d ResourceRecords, so you may consider limiting the number of records?",
-						*c.Action, *c.ResourceRecordSet.Name, *c.ResourceRecordSet.Type, nLogicalRecordsInChange, nRecordsAsViewedByRoute53LimitsInChange, route53ResourceRecordsPerBatchLimit)
+						*c.Action, *c.ResourceRecordSet.Name, *c.ResourceRecordSet.Type, nLogicalRecordsInChange, nRecordsAsViewedByRoute53LimitsInChange)
 				} else {
 					log.Infof("Desired change: %s %s %s (%d records, %d records in route53.Change)", *c.Action, *c.ResourceRecordSet.Name, *c.ResourceRecordSet.Type, nLogicalRecordsInChange, nRecordsAsViewedByRoute53LimitsInChange)
 				}
@@ -417,7 +417,8 @@ func (p *AWSProvider) newChange(action string, endpoint *endpoint.Endpoint) *rou
 		nEndpointsLimit := len(endpoint.Targets)
 		if nEndpointsLimit >= maxEndpointsInRoute53 {
 			nEndpointsLimit = maxEndpointsInRoute53
-			log.Warnf("Truncated endpoint targets to %d for endpoint %s (%d targets) as Route53 cannot handle more than %d resource records", nEndpointsLimit, aws.String(endpoint.Targets[0]), len(endpoint.Targets), maxEndpointsInRoute53)
+			log.Warnf("Truncated endpoint targets to %d for endpoint %s (%d targets) as Route53 cannot handle more than %d resource records", nEndpointsLimit, *aws.String(endpoint.Targets[0]), len(endpoint.Targets), maxEndpointsInRoute53)
+			panic(fmt.Sprintf("FUCK tried to create endpoint with %d targets", len(endpoint.Targets)))
 		}
 		change.ResourceRecordSet.ResourceRecords = make([]*route53.ResourceRecord, nEndpointsLimit)
 		for i := 0; i < nEndpointsLimit; i++ {

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -22,12 +22,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/external-dns/endpoint"
+	"github.com/DataDog/external-dns/plan"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
-	"github.com/kubernetes-incubator/external-dns/endpoint"
-	"github.com/kubernetes-incubator/external-dns/plan"
 	"github.com/linki/instrumented_http"
 	log "github.com/sirupsen/logrus"
 )
@@ -211,7 +211,7 @@ func (p *AWSProvider) Records() (endpoints []*endpoint.Endpoint, _ error) {
 	f := func(resp *route53.ListResourceRecordSetsOutput, lastPage bool) (shouldContinue bool) {
 		for _, r := range resp.ResourceRecordSets {
 			// TODO(linki, ownership): Remove once ownership system is in place.
-			// See: https://github.com/kubernetes-incubator/external-dns/pull/122/files/74e2c3d3e237411e619aefc5aab694742001cdec#r109863370
+			// See: https://github.com/DataDog/external-dns/pull/122/files/74e2c3d3e237411e619aefc5aab694742001cdec#r109863370
 
 			if !supportedRecordType(aws.StringValue(r.Type)) {
 				continue
@@ -418,7 +418,6 @@ func (p *AWSProvider) newChange(action string, endpoint *endpoint.Endpoint) *rou
 		if nEndpointsLimit >= maxEndpointsInRoute53 {
 			nEndpointsLimit = maxEndpointsInRoute53
 			log.Warnf("Truncated endpoint targets to %d for endpoint %s (%d targets) as Route53 cannot handle more than %d resource records", nEndpointsLimit, *aws.String(endpoint.Targets[0]), len(endpoint.Targets), maxEndpointsInRoute53)
-			panic(fmt.Sprintf("FUCK tried to create endpoint with %d targets", len(endpoint.Targets)))
 		}
 		change.ResourceRecordSet.ResourceRecords = make([]*route53.ResourceRecord, nEndpointsLimit)
 		for i := 0; i < nEndpointsLimit; i++ {

--- a/provider/aws_sd.go
+++ b/provider/aws_sd.go
@@ -27,9 +27,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	sd "github.com/aws/aws-sdk-go/service/servicediscovery"
-	"github.com/DataDog/external-dns/endpoint"
-	"github.com/DataDog/external-dns/pkg/apis/externaldns"
-	"github.com/DataDog/external-dns/plan"
+	"github.com/kubernetes-incubator/external-dns/endpoint"
+	"github.com/kubernetes-incubator/external-dns/pkg/apis/externaldns"
+	"github.com/kubernetes-incubator/external-dns/plan"
 	"github.com/linki/instrumented_http"
 	log "github.com/sirupsen/logrus"
 )

--- a/provider/aws_sd.go
+++ b/provider/aws_sd.go
@@ -27,9 +27,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	sd "github.com/aws/aws-sdk-go/service/servicediscovery"
-	"github.com/kubernetes-incubator/external-dns/endpoint"
-	"github.com/kubernetes-incubator/external-dns/pkg/apis/externaldns"
-	"github.com/kubernetes-incubator/external-dns/plan"
+	"github.com/DataDog/external-dns/endpoint"
+	"github.com/DataDog/external-dns/pkg/apis/externaldns"
+	"github.com/DataDog/external-dns/plan"
 	"github.com/linki/instrumented_http"
 	log "github.com/sirupsen/logrus"
 )

--- a/provider/aws_sd_test.go
+++ b/provider/aws_sd_test.go
@@ -18,16 +18,17 @@ package provider
 
 import (
 	"errors"
+	"fmt"
 	"math/rand"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/DataDog/external-dns/endpoint"
+	"github.com/DataDog/external-dns/internal/testutils"
+	"github.com/DataDog/external-dns/plan"
 	"github.com/aws/aws-sdk-go/aws"
 	sd "github.com/aws/aws-sdk-go/service/servicediscovery"
-	"github.com/kubernetes-incubator/external-dns/endpoint"
-	"github.com/kubernetes-incubator/external-dns/internal/testutils"
-	"github.com/kubernetes-incubator/external-dns/plan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,7 +50,7 @@ type AWSSDClientStub struct {
 func (s *AWSSDClientStub) CreateService(input *sd.CreateServiceInput) (*sd.CreateServiceOutput, error) {
 
 	srv := &sd.Service{
-		Id:               aws.String(string(rand.Intn(10000))),
+		Id:               aws.String(fmt.Sprintf("%d", (rand.Intn(10000)))),
 		DnsConfig:        input.DnsConfig,
 		Name:             input.Name,
 		Description:      input.Description,

--- a/provider/aws_sd_test.go
+++ b/provider/aws_sd_test.go
@@ -24,9 +24,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/external-dns/endpoint"
-	"github.com/DataDog/external-dns/internal/testutils"
-	"github.com/DataDog/external-dns/plan"
+	"github.com/kubernetes-incubator/external-dns/endpoint"
+	"github.com/kubernetes-incubator/external-dns/internal/testutils"
+	"github.com/kubernetes-incubator/external-dns/plan"
 	"github.com/aws/aws-sdk-go/aws"
 	sd "github.com/aws/aws-sdk-go/service/servicediscovery"
 	"github.com/stretchr/testify/assert"

--- a/provider/aws_test.go
+++ b/provider/aws_test.go
@@ -25,9 +25,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/external-dns/endpoint"
-	"github.com/DataDog/external-dns/internal/testutils"
-	"github.com/DataDog/external-dns/plan"
+	"github.com/kubernetes-incubator/external-dns/endpoint"
+	"github.com/kubernetes-incubator/external-dns/internal/testutils"
+	"github.com/kubernetes-incubator/external-dns/plan"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/stretchr/testify/assert"
@@ -922,7 +922,7 @@ func TestAWSSuitableZones(t *testing.T) {
 		{"foobar.example.org.", []*route53.HostedZone{zones["example-org-private"], zones["example-org"]}},
 
 		// all matching private zones are suitable
-		// https://github.com/DataDog/external-dns/pull/356
+		// https://github.com/kubernetes-incubator/external-dns/pull/356
 		{"bar.example.org.", []*route53.HostedZone{zones["example-org-private"], zones["bar-example-org-private"], zones["bar-example-org"]}},
 
 		{"foo.bar.example.org.", []*route53.HostedZone{zones["example-org-private"], zones["bar-example-org-private"], zones["bar-example-org"]}},


### PR DESCRIPTION
This is a partial fix to one of the failures in https://datadoghq.atlassian.net/browse/COMPUTE-495 - if an endpoint has >400 targets, external-dns will incorrectly create a change with more records in the recordset than route53 is chill with (400 is the max). So, we truncate the endpoint.Targets to 400 to make sure the change goes through, and log a warning.

## Tests

1. make sure an endpoint with >400 targets is truncated to the first 400 targets:

```
=== RUN   TestAWSsubmitChangesTooManyEndpointTargets
time="2020-10-01T17:47:51-04:00" level=info msg="All records are already up to date"
Creating endpoint with 500 targets: largerecord.zone-1.ext-dns-test-2.teapot.zalan.do 300 IN A 0.0.0.0;0.0.0.1;0.0.0.2;0.0.0.3;0.0.0.4;0.0.0.5;0.0.0.6;0.0.0.7;0.0.0.8;0.0.0.9;0.0.0.
10;0.0.0.11;0.0.0.12;0.0.0.13;0.0.0.14;0.0.0.15;0.0.0.16;0.0.0.17;0.0.0.18;0.0.0.19;0.0.0.20;0.0.0.21;0.0.0.22;0.0.0.23;0.0.0.24;0.0.0.25;0.0.0.26;0.0.0.27;0.0.0.28;0.0.0.29;0.0.0.3
0;0.0.0.31;0.0.0.32;0.0.0.33;0.0.0.34;0.0.0.35;0.0.0.36;0.0.0.37;0.0.0.38;0.0.0.39;0.0.0.40;0.0.0.41;0.0.0.42;0.0.0.43;0.0.0.44;0.0.0.45;0.0.0.46;0.0.0.47;0.0.0.48;0.0.0.49;0.0.0.50
;0.0.0.51;0.0.0.52;0.0.0.53;0.0.0.54;0.0.0.55;0.0.0.56;0.0.0.57;0.0.0.58;0.0.0.59;0.0.0.60;0.0.0.61;0.0.0.62;0.0.0.63;0.0.0.64;0.0.0.65;0.0.0.66;0.0.0.67;0.0.0.68;0.0.0.69;0.0.0.70;
0.0.0.71;0.0.0.72;0.0.0.73;0.0.0.74;0.0.0.75;0.0.0.76;0.0.0.77;0.0.0.78;0.0.0.79;0.0.0.80;0.0.0.81;0.0.0.82;0.0.0.83;0.0.0.84;0.0.0.85;0.0.0.86;0.0.0.87;0.0.0.88;0.0.0.89;0.0.0.90;0
.0.0.91;0.0.0.92;0.0.0.93;0.0.0.94;0.0.0.95;0.0.0.96;0.0.0.97;0.0.0.98;0.0.0.99;0.0.0.100;0.0.0.101;0.0.0.102;0.0.0.103;0.0.0.104;0.0.0.105;0.0.0.106;0.0.0.107;0.0.0.108;0.0.0.109;0
.0.0.110;0.0.0.111;0.0.0.112;0.0.0.113;0.0.0.114;0.0.0.115;0.0.0.116;0.0.0.117;0.0.0.118;0.0.0.119;0.0.0.120;0.0.0.121;0.0.0.122;0.0.0.123;0.0.0.124;0.0.0.125;0.0.0.126;0.0.0.127;0.
0.0.128;0.0.0.129;0.0.0.130;0.0.0.131;0.0.0.132;0.0.0.133;0.0.0.134;0.0.0.135;0.0.0.136;0.0.0.137;0.0.0.138;0.0.0.139;0.0.0.140;0.0.0.141;0.0.0.142;0.0.0.143;0.0.0.144;0.0.0.145;0.0
.0.146;0.0.0.147;0.0.0.148;0.0.0.149;0.0.0.150;0.0.0.151;0.0.0.152;0.0.0.153;0.0.0.154;0.0.0.155;0.0.0.156;0.0.0.157;0.0.0.158;0.0.0.159;0.0.0.160;0.0.0.161;0.0.0.162;0.0.0.163;0.0.
0.164;0.0.0.165;0.0.0.166;0.0.0.167;0.0.0.168;0.0.0.169;0.0.0.170;0.0.0.171;0.0.0.172;0.0.0.173;0.0.0.174;0.0.0.175;0.0.0.176;0.0.0.177;0.0.0.178;0.0.0.179;0.0.0.180;0.0.0.181;0.0.0
.182;0.0.0.183;0.0.0.184;0.0.0.185;0.0.0.186;0.0.0.187;0.0.0.188;0.0.0.189;0.0.0.190;0.0.0.191;0.0.0.192;0.0.0.193;0.0.0.194;0.0.0.195;0.0.0.196;0.0.0.197;0.0.0.198;0.0.0.199;0.0.0.
200;0.0.0.201;0.0.0.202;0.0.0.203;0.0.0.204;0.0.0.205;0.0.0.206;0.0.0.207;0.0.0.208;0.0.0.209;0.0.0.210;0.0.0.211;0.0.0.212;0.0.0.213;0.0.0.214;0.0.0.215;0.0.0.216;0.0.0.217;0.0.0.2
18;0.0.0.219;0.0.0.220;0.0.0.221;0.0.0.222;0.0.0.223;0.0.0.224;0.0.0.225;0.0.0.226;0.0.0.227;0.0.0.228;0.0.0.229;0.0.0.230;0.0.0.231;0.0.0.232;0.0.0.233;0.0.0.234;0.0.0.235;0.0.0.23
6;0.0.0.237;0.0.0.238;0.0.0.239;0.0.0.240;0.0.0.241;0.0.0.242;0.0.0.243;0.0.0.244;0.0.0.245;0.0.0.246;0.0.0.247;0.0.0.248;0.0.0.249;0.0.0.250;0.0.0.251;0.0.0.252;0.0.0.253;0.0.0.254
;0.0.0.255;0.0.1.0;0.0.1.1;0.0.1.2;0.0.1.3;0.0.1.4;0.0.1.5;0.0.1.6;0.0.1.7;0.0.1.8;0.0.1.9;0.0.1.10;0.0.1.11;0.0.1.12;0.0.1.13;0.0.1.14;0.0.1.15;0.0.1.16;0.0.1.17;0.0.1.18;0.0.1.19;
0.0.1.20;0.0.1.21;0.0.1.22;0.0.1.23;0.0.1.24;0.0.1.25;0.0.1.26;0.0.1.27;0.0.1.28;0.0.1.29;0.0.1.30;0.0.1.31;0.0.1.32;0.0.1.33;0.0.1.34;0.0.1.35;0.0.1.36;0.0.1.37;0.0.1.38;0.0.1.39;0
.0.1.40;0.0.1.41;0.0.1.42;0.0.1.43;0.0.1.44;0.0.1.45;0.0.1.46;0.0.1.47;0.0.1.48;0.0.1.49;0.0.1.50;0.0.1.51;0.0.1.52;0.0.1.53;0.0.1.54;0.0.1.55;0.0.1.56;0.0.1.57;0.0.1.58;0.0.1.59;0.
0.1.60;0.0.1.61;0.0.1.62;0.0.1.63;0.0.1.64;0.0.1.65;0.0.1.66;0.0.1.67;0.0.1.68;0.0.1.69;0.0.1.70;0.0.1.71;0.0.1.72;0.0.1.73;0.0.1.74;0.0.1.75;0.0.1.76;0.0.1.77;0.0.1.78;0.0.1.79;0.0
.1.80;0.0.1.81;0.0.1.82;0.0.1.83;0.0.1.84;0.0.1.85;0.0.1.86;0.0.1.87;0.0.1.88;0.0.1.89;0.0.1.90;0.0.1.91;0.0.1.92;0.0.1.93;0.0.1.94;0.0.1.95;0.0.1.96;0.0.1.97;0.0.1.98;0.0.1.99;0.0.
1.100;0.0.1.101;0.0.1.102;0.0.1.103;0.0.1.104;0.0.1.105;0.0.1.106;0.0.1.107;0.0.1.108;0.0.1.109;0.0.1.110;0.0.1.111;0.0.1.112;0.0.1.113;0.0.1.114;0.0.1.115;0.0.1.116;0.0.1.117;0.0.1
.118;0.0.1.119;0.0.1.120;0.0.1.121;0.0.1.122;0.0.1.123;0.0.1.124;0.0.1.125;0.0.1.126;0.0.1.127;0.0.1.128;0.0.1.129;0.0.1.130;0.0.1.131;0.0.1.132;0.0.1.133;0.0.1.134;0.0.1.135;0.0.1.
136;0.0.1.137;0.0.1.138;0.0.1.139;0.0.1.140;0.0.1.141;0.0.1.142;0.0.1.143;0.0.1.144;0.0.1.145;0.0.1.146;0.0.1.147;0.0.1.148;0.0.1.149;0.0.1.150;0.0.1.151;0.0.1.152;0.0.1.153;0.0.1.1
54;0.0.1.155;0.0.1.156;0.0.1.157;0.0.1.158;0.0.1.159;0.0.1.160;0.0.1.161;0.0.1.162;0.0.1.163;0.0.1.164;0.0.1.165;0.0.1.166;0.0.1.167;0.0.1.168;0.0.1.169;0.0.1.170;0.0.1.171;0.0.1.17
2;0.0.1.173;0.0.1.174;0.0.1.175;0.0.1.176;0.0.1.177;0.0.1.178;0.0.1.179;0.0.1.180;0.0.1.181;0.0.1.182;0.0.1.183;0.0.1.184;0.0.1.185;0.0.1.186;0.0.1.187;0.0.1.188;0.0.1.189;0.0.1.190
;0.0.1.191;0.0.1.192;0.0.1.193;0.0.1.194;0.0.1.195;0.0.1.196;0.0.1.197;0.0.1.198;0.0.1.199;0.0.1.200;0.0.1.201;0.0.1.202;0.0.1.203;0.0.1.204;0.0.1.205;0.0.1.206;0.0.1.207;0.0.1.208;
0.0.1.209;0.0.1.210;0.0.1.211;0.0.1.212;0.0.1.213;0.0.1.214;0.0.1.215;0.0.1.216;0.0.1.217;0.0.1.218;0.0.1.219;0.0.1.220;0.0.1.221;0.0.1.222;0.0.1.223;0.0.1.224;0.0.1.225;0.0.1.226;0
.0.1.227;0.0.1.228;0.0.1.229;0.0.1.230;0.0.1.231;0.0.1.232;0.0.1.233;0.0.1.234;0.0.1.235;0.0.1.236;0.0.1.237;0.0.1.238;0.0.1.239;0.0.1.240;0.0.1.241;0.0.1.242;0.0.1.243 map[]
time="2020-10-01T17:47:52-04:00" level=warning msg="Truncated endpoint targets to 400 for endpoint 0.0.0.0 (500 targets) as Route53 cannot handle more than 400 resource records"
time="2020-10-01T17:47:52-04:00" level=warning msg="Desired change: CREATE largerecord.zone-1.ext-dns-test-2.teapot.zalan.do A has 400 ResourceRecords, which is pretty spicy. Route5
3 limits Changes to 400 ResourceRecords, so you may consider limiting the number of records?"
time="2020-10-01T17:47:52-04:00" level=info msg="Attempting to update 400 ResourceRecords across 1 change sets, with a total of 400 changes as measured by Route53"
time="2020-10-01T17:47:52-04:00" level=info msg="1 record(s) in zone zone-1.ext-dns-test-2.teapot.zalan.do. were successfully updated"
--- PASS: TestAWSsubmitChangesTooManyEndpointTargets (2.28s)
```