### PR TITLE
Ensure records are sorted before taking subslice

### DIFF
--- a/provider/aws.go
+++ b/provider/aws.go
@@ -444,13 +444,11 @@ func stableEndpointTargetSubset(ep *endpoint.Endpoint) []string {
 
 	log.Warnf("Truncating and sorting %d (of %d) endpoint targets for endpoint %s, which is in excess of Route53 limits of ResourceRecord per ResourceRecordSet", maxResourceRecordsPerResourceRecordSet, len(ep.Targets), ep.DNSName)
 	hashedTargets := map[string]string{}
+	var hashedTargetKeys []string
 	// hash, then sort targets, so we have a stable yet random subset of IPs
 	for _, val := range ep.Targets {
 		k := fmt.Sprintf("%x", md5.Sum([]byte(val)))
 		hashedTargets[k] = val
-	}
-	var hashedTargetKeys []string
-	for k := range hashedTargets {
 		hashedTargetKeys = append(hashedTargetKeys, k)
 	}
 

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -323,7 +323,7 @@ func (p *AWSProvider) submitChanges(changes []*route53.Change) error {
 				nLogicalRecordsInChange := len(c.ResourceRecordSet.ResourceRecords)
 				nRecordsAsViewedByRoute53LimitsInChange := nLogicalRecordsInChange * multiplier
 				if nRecordsAsViewedByRoute53LimitsInChange > 200 {
-					log.Warnf("Desired change: %s %s %s has %d ResourceRecords, which is pretty spicy. Route53 limits Changes to %d ResourceRecords, so you may consider limiting the number of records?",
+					log.Warnf("Desired change: %s %s %s has %d ResourceRecords, which is pretty spicy. Route53 limits changes to %d ResourceRecords, so you may consider limiting the number of records?",
 						*c.Action, *c.ResourceRecordSet.Name, *c.ResourceRecordSet.Type, nLogicalRecordsInChange, nRecordsAsViewedByRoute53LimitsInChange)
 				} else {
 					log.Infof("Desired change: %s %s %s (%d records, %d records in route53.Change)", *c.Action, *c.ResourceRecordSet.Name, *c.ResourceRecordSet.Type, nLogicalRecordsInChange, nRecordsAsViewedByRoute53LimitsInChange)
@@ -420,7 +420,7 @@ func (p *AWSProvider) newChange(action string, endpoint *endpoint.Endpoint) *rou
 		nEndpointsLimit := len(endpoint.Targets)
 		if nEndpointsLimit >= maxResourceRecordsPerEntry {
 			nEndpointsLimit = maxResourceRecordsPerEntry
-			log.Warnf("Truncating and sorting %d (of %d) endpoint targets for endpoint %s as Route53 cannot handle more than %d resource records", nEndpointsLimit, len(endpoint.Targets), *aws.String(endpoint.Targets[0]), maxResourceRecordsPerEntry)
+			log.Warnf("Truncating and sorting %d (of %d) endpoint targets for endpoint %s as Route53 cannot handle more than %d resource records", nEndpointsLimit, len(endpoint.Targets), endpoint.DNSName, maxResourceRecordsPerEntry)
 		}
 		targets := make([]string, nEndpointsLimit)
 		copy(targets, endpoint.Targets[0:nEndpointsLimit])

--- a/provider/aws_test.go
+++ b/provider/aws_test.go
@@ -586,8 +586,8 @@ func TestAWSChangesByZones(t *testing.T) {
 }
 
 func TestAWSsubmitChangesTooManyEndpointTargets(t *testing.T) {
-	// Route53 bails if there are more than maxResourceRecordsPerEntry records in a recordset, so we blindly
-	// limit an Endpoint.Targets to the first maxResourceRecordsPerEntry to avoid this failure
+	// Route53 bails if there are more than maxResourceRecordsPerResourceRecordSet records in a recordset, so we blindly
+	// limit an Endpoint.Targets to the first maxResourceRecordsPerResourceRecordSet to avoid this failure
 	provider, _ := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), defaultEvaluateTargetHealth, false, []*endpoint.Endpoint{})
 	const subnets = 16
 	const hosts = defaultBatchChangeSize / subnets
@@ -598,9 +598,9 @@ func TestAWSsubmitChangesTooManyEndpointTargets(t *testing.T) {
 	hostname := "largerecord.zone-1.ext-dns-test-2.teapot.zalan.do"
 	targets := []string{}
 	expectedTargets := []string{}
-	// create maxResourceRecordsPerEntry + 100 IPs descending order, to confirm
-	// expected endpoints are the first maxResourceRecordsPerEntry in ascending order
-	for i := uint32(maxResourceRecordsPerEntry + 100); i > 0; i-- {
+	// create maxResourceRecordsPerResourceRecordSet + 100 IPs descending order, to confirm
+	// expected endpoints are the first maxResourceRecordsPerResourceRecordSet in ascending order
+	for i := uint32(maxResourceRecordsPerResourceRecordSet + 100); i > 0; i-- {
 		ipByte := make([]byte, 4)
 		binary.BigEndian.PutUint32(ipByte, i)
 		ip := net.IP(ipByte).String()

--- a/provider/aws_test.go
+++ b/provider/aws_test.go
@@ -611,8 +611,7 @@ func TestAWSsubmitChangesTooManyEndpointTargets(t *testing.T) {
 	ep := endpoint.NewEndpointWithTTL(hostname, endpoint.RecordTypeA, endpoint.TTL(recordTTL), targets...)
 	endpoints = append(endpoints, ep)
 
-	sort.Strings(expectedTargets)
-	expectedTargets = expectedTargets[0:maxResourceRecordsPerEntry]
+	expectedTargets = stableEndpointTargetSubset(ep)
 	fmt.Printf("Expecting endpoint with %d targets: %v\n", len(expectedTargets), expectedTargets)
 	expectedEp := endpoint.NewEndpointWithTTL(hostname, endpoint.RecordTypeA, endpoint.TTL(recordTTL), expectedTargets...)
 	expectedEndpoints = append(expectedEndpoints, expectedEp)

--- a/provider/aws_test.go
+++ b/provider/aws_test.go
@@ -611,8 +611,8 @@ func TestAWSsubmitChangesTooManyEndpointTargets(t *testing.T) {
 	ep := endpoint.NewEndpointWithTTL(hostname, endpoint.RecordTypeA, endpoint.TTL(recordTTL), targets...)
 	endpoints = append(endpoints, ep)
 
-	expectedTargets = expectedTargets[0:maxResourceRecordsPerEntry]
 	sort.Strings(expectedTargets)
+	expectedTargets = expectedTargets[0:maxResourceRecordsPerEntry]
 	fmt.Printf("Expecting endpoint with %d targets: %v\n", len(expectedTargets), expectedTargets)
 	expectedEp := endpoint.NewEndpointWithTTL(hostname, endpoint.RecordTypeA, endpoint.TTL(recordTTL), expectedTargets...)
 	expectedEndpoints = append(expectedEndpoints, expectedEp)


### PR DESCRIPTION
This PR makes sure that we sort all endpoint targets before taking a subslice, only if we exceed the maximum number of records. This ensures that the change set will remain stable even if the apiserver happens to give us endpoint targets in random order each iteration.

Additionally, I accidentally was logging the first IP instead of DNSName, which was a bit confusing. This PR changes output like:

```
time="2020-10-02T20:41:19Z" level=warning msg="Truncating and sorting 400 (of 402) endpoint targets for endpoint 10.140.128.111 as Route53 cannot handle more than 400 resource records"
 time="2020-10-02T20:41:19Z" level=warning msg="Desired change: CREATE echoserver.datadog.svc.fury.us1.staging.dog A has 400 ResourceRecords, which is pretty spicy. Route53 limits Changes to 400 ResourceRecords, so you may consider limiting the number of records?"
```

to be like:

```
time="2020-10-02T20:41:19Z" level=warning msg="Truncating and sorting 400 (of 402) endpoint targets for endpoint echoserver.datadog.svc.fury.us1.staging.dog as Route53 cannot handle more than 400 resource records"
 time="2020-10-02T20:41:19Z" level=warning msg="Desired change: CREATE echoserver.datadog.svc.fury.us1.staging.dog A has 400 ResourceRecords, which is pretty spicy. Route53 limits changes to 400 ResourceRecords, so you may consider limiting the number of records?"
```