### PR TITLE
[FABCTRL-384] Limit ResourceRecord Elements in a Change Batch

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -742,12 +742,12 @@ func getResourceRecordCountPerChangeSet(cs []*route53.Change) int {
 	return rrsetCount
 }
 
-func doesResourceRecordCountExceedsLimitPerChangeSet(cs []*route53.Change, maxLimit int) bool {
+func doesResourceRecordCountExceedLimitPerChangeSet(cs []*route53.Change, maxLimit int) bool {
 	return getResourceRecordCountPerChangeSet(cs) <= maxLimit
 }
 
 func batchChangeSet(cs []*route53.Change, batchSize int) [][]*route53.Change {
-	if len(cs) <= batchSize && doesResourceRecordCountExceedsLimitPerChangeSet(cs, maxResourceRecordsPerChangeBatch) {
+	if len(cs) <= batchSize && doesResourceRecordCountExceedLimitPerChangeSet(cs, maxResourceRecordsPerChangeBatch) {
 		res := sortChangesByActionNameType(cs)
 		return [][]*route53.Change{res}
 	}
@@ -777,7 +777,7 @@ func batchChangeSet(cs []*route53.Change, batchSize int) [][]*route53.Change {
 		var existingBatch bool
 		for i, b := range batchChanges {
 			potentialBatch := append(batchChanges[i], changesByName[name]...)
-			if len(b)+totalChangesByName <= batchSize && doesResourceRecordCountExceedsLimitPerChangeSet(potentialBatch, maxResourceRecordsPerChangeBatch) {
+			if len(b)+totalChangesByName <= batchSize && doesResourceRecordCountExceedLimitPerChangeSet(potentialBatch, maxResourceRecordsPerChangeBatch) {
 				batchChanges[i] = potentialBatch
 				existingBatch = true
 				break

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -742,12 +742,12 @@ func getResourceRecordCountPerChangeSet(cs []*route53.Change) int {
 	return rrsetCount
 }
 
-func doesResourceRecordCountExceedLimitPerChangeSet(cs []*route53.Change, maxLimit int) bool {
+func isResourceRecordCountBelowLimitPerChangeSet(cs []*route53.Change, maxLimit int) bool {
 	return getResourceRecordCountPerChangeSet(cs) <= maxLimit
 }
 
 func batchChangeSet(cs []*route53.Change, batchSize int) [][]*route53.Change {
-	if len(cs) <= batchSize && doesResourceRecordCountExceedLimitPerChangeSet(cs, maxResourceRecordsPerChangeBatch) {
+	if len(cs) <= batchSize && isResourceRecordCountBelowLimitPerChangeSet(cs, maxResourceRecordsPerChangeBatch) {
 		res := sortChangesByActionNameType(cs)
 		return [][]*route53.Change{res}
 	}
@@ -777,7 +777,7 @@ func batchChangeSet(cs []*route53.Change, batchSize int) [][]*route53.Change {
 		var existingBatch bool
 		for i, b := range batchChanges {
 			potentialBatch := append(batchChanges[i], changesByName[name]...)
-			if len(b)+totalChangesByName <= batchSize && doesResourceRecordCountExceedLimitPerChangeSet(potentialBatch, maxResourceRecordsPerChangeBatch) {
+			if len(b)+totalChangesByName <= batchSize && isResourceRecordCountBelowLimitPerChangeSet(potentialBatch, maxResourceRecordsPerChangeBatch) {
 				batchChanges[i] = potentialBatch
 				existingBatch = true
 				break

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -942,6 +942,102 @@ func TestAWSBatchChangeSetExceedingNameChange(t *testing.T) {
 	require.Equal(t, 0, len(batchCs))
 }
 
+func TestAWSBatchChangeSetExceedingRRElementCount(t *testing.T) {
+	var cs []*route53.Change
+
+	// Creates a cs with 505 resource record elements
+	for i := 1; i <= 101; i += 1 {
+		cs = append(cs, &route53.Change{
+			Action: aws.String(route53.ChangeActionCreate),
+			ResourceRecordSet: &route53.ResourceRecordSet{
+				Name: aws.String(fmt.Sprintf("host-%d", i)),
+				Type: aws.String("A"),
+				ResourceRecords: []*route53.ResourceRecord{
+					{Value: aws.String("foo1.example.org")},
+					{Value: aws.String("foo2.example.org")},
+					{Value: aws.String("foo3.example.org")},
+					{Value: aws.String("foo4.example.org")},
+					{Value: aws.String("foo5.example.org")},
+				},
+			},
+		})
+	}
+
+	batchCs := batchChangeSet(cs, defaultBatchChangeSize)
+
+	// Check that the cs was split up into 2 batches
+	require.Equal(t, 2, len(batchCs))
+}
+
+func TestGetResourceRecordElementCount(t *testing.T) {
+	var cs []*route53.Change
+
+	for i := 1; i <= 10; i += 1 {
+		cs = append(cs, &route53.Change{
+			Action: aws.String(route53.ChangeActionCreate),
+			ResourceRecordSet: &route53.ResourceRecordSet{
+				Name: aws.String(fmt.Sprintf("host-%d", i)),
+				Type: aws.String("A"),
+				ResourceRecords: []*route53.ResourceRecord{
+					{Value: aws.String("foo1.example.org")},
+					{Value: aws.String("foo2.example.org")},
+					{Value: aws.String("foo3.example.org")},
+				},
+			},
+		})
+	}
+
+	ResourceRecordCount := _getResourceRecordElementCount(cs)
+
+	require.Equal(t, 30, ResourceRecordCount)
+}
+
+func TestGetResourceRecordElementCountEmptyList(t *testing.T) {
+	var cs []*route53.Change
+
+	for i := 1; i <= 10; i += 1 {
+		cs = append(cs, &route53.Change{
+			Action: aws.String(route53.ChangeActionCreate),
+			ResourceRecordSet: &route53.ResourceRecordSet{
+				Name: aws.String(fmt.Sprintf("host-%d", i)),
+				Type: aws.String("A"),
+			},
+		})
+	}
+
+	ResourceRecordCount := _getResourceRecordElementCount(cs)
+
+	require.Equal(t, 0, ResourceRecordCount)
+}
+
+func TestGetResourceRecordElementBool(t *testing.T) {
+	var cs []*route53.Change
+
+	for i := 1; i <= 10; i += 1 {
+		cs = append(cs, &route53.Change{
+			Action: aws.String(route53.ChangeActionCreate),
+			ResourceRecordSet: &route53.ResourceRecordSet{
+				Name: aws.String(fmt.Sprintf("host-%d", i)),
+				Type: aws.String("A"),
+				ResourceRecords: []*route53.ResourceRecord{
+					{Value: aws.String("foo1.example.org")},
+					{Value: aws.String("foo2.example.org")},
+					{Value: aws.String("foo3.example.org")},
+				},
+			},
+		})
+	}
+
+	ResourceRecordBool := getResourceRecordElementBool(cs, 40)
+	require.Equal(t, true, ResourceRecordBool)
+
+	ResourceRecordBool = getResourceRecordElementBool(cs, 30)
+	require.Equal(t, true, ResourceRecordBool)
+
+	ResourceRecordBool = getResourceRecordElementBool(cs, 20)
+	require.Equal(t, false, ResourceRecordBool)
+}
+
 func validateEndpoints(t *testing.T, endpoints []*endpoint.Endpoint, expected []*endpoint.Endpoint) {
 	assert.True(t, testutils.SameEndpoints(endpoints, expected), "actual and expected endpoints don't match. %+v:%+v", endpoints, expected)
 }

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -969,7 +969,7 @@ func TestAWSBatchChangeSetExceedingRRElementCount(t *testing.T) {
 	require.Equal(t, 2, len(batchCs))
 }
 
-func TestGetResourceRecordElementCount(t *testing.T) {
+func TestGetResourceRecordCountPerChangeSet(t *testing.T) {
 	var cs []*route53.Change
 
 	for i := 1; i <= 10; i += 1 {
@@ -987,12 +987,12 @@ func TestGetResourceRecordElementCount(t *testing.T) {
 		})
 	}
 
-	ResourceRecordCount := _getResourceRecordElementCount(cs)
+	ResourceRecordCount := getResourceRecordCountPerChangeSet(cs)
 
 	require.Equal(t, 30, ResourceRecordCount)
 }
 
-func TestGetResourceRecordElementCountEmptyList(t *testing.T) {
+func TestGetResourceRecordCountPerChangeSetEmptyList(t *testing.T) {
 	var cs []*route53.Change
 
 	for i := 1; i <= 10; i += 1 {
@@ -1005,12 +1005,12 @@ func TestGetResourceRecordElementCountEmptyList(t *testing.T) {
 		})
 	}
 
-	ResourceRecordCount := _getResourceRecordElementCount(cs)
+	ResourceRecordCount := getResourceRecordCountPerChangeSet(cs)
 
 	require.Equal(t, 0, ResourceRecordCount)
 }
 
-func TestGetResourceRecordElementBool(t *testing.T) {
+func TestDoesResourceRecordCountExceedsLimitPerChangeSet(t *testing.T) {
 	var cs []*route53.Change
 
 	for i := 1; i <= 10; i += 1 {
@@ -1028,13 +1028,13 @@ func TestGetResourceRecordElementBool(t *testing.T) {
 		})
 	}
 
-	ResourceRecordBool := getResourceRecordElementBool(cs, 40)
+	ResourceRecordBool := doesResourceRecordCountExceedsLimitPerChangeSet(cs, 40)
 	require.Equal(t, true, ResourceRecordBool)
 
-	ResourceRecordBool = getResourceRecordElementBool(cs, 30)
+	ResourceRecordBool = doesResourceRecordCountExceedsLimitPerChangeSet(cs, 30)
 	require.Equal(t, true, ResourceRecordBool)
 
-	ResourceRecordBool = getResourceRecordElementBool(cs, 20)
+	ResourceRecordBool = doesResourceRecordCountExceedsLimitPerChangeSet(cs, 20)
 	require.Equal(t, false, ResourceRecordBool)
 }
 

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -1010,7 +1010,7 @@ func TestGetResourceRecordCountPerChangeSetEmptyList(t *testing.T) {
 	require.Equal(t, 0, ResourceRecordCount)
 }
 
-func TestDoesResourceRecordCountExceedsLimitPerChangeSet(t *testing.T) {
+func TestDoesResourceRecordCountExceedLimitPerChangeSet(t *testing.T) {
 	var cs []*route53.Change
 
 	for i := 1; i <= 10; i += 1 {
@@ -1028,13 +1028,13 @@ func TestDoesResourceRecordCountExceedsLimitPerChangeSet(t *testing.T) {
 		})
 	}
 
-	ResourceRecordBool := doesResourceRecordCountExceedsLimitPerChangeSet(cs, 40)
+	ResourceRecordBool := doesResourceRecordCountExceedLimitPerChangeSet(cs, 40)
 	require.Equal(t, true, ResourceRecordBool)
 
-	ResourceRecordBool = doesResourceRecordCountExceedsLimitPerChangeSet(cs, 30)
+	ResourceRecordBool = doesResourceRecordCountExceedLimitPerChangeSet(cs, 30)
 	require.Equal(t, true, ResourceRecordBool)
 
-	ResourceRecordBool = doesResourceRecordCountExceedsLimitPerChangeSet(cs, 20)
+	ResourceRecordBool = doesResourceRecordCountExceedLimitPerChangeSet(cs, 20)
 	require.Equal(t, false, ResourceRecordBool)
 }
 

--- a/provider/aws/aws_test.go
+++ b/provider/aws/aws_test.go
@@ -1010,7 +1010,7 @@ func TestGetResourceRecordCountPerChangeSetEmptyList(t *testing.T) {
 	require.Equal(t, 0, ResourceRecordCount)
 }
 
-func TestDoesResourceRecordCountExceedLimitPerChangeSet(t *testing.T) {
+func TestIsResourceRecordCountBelowLimitPerChangeSet(t *testing.T) {
 	var cs []*route53.Change
 
 	for i := 1; i <= 10; i += 1 {
@@ -1028,13 +1028,13 @@ func TestDoesResourceRecordCountExceedLimitPerChangeSet(t *testing.T) {
 		})
 	}
 
-	ResourceRecordBool := doesResourceRecordCountExceedLimitPerChangeSet(cs, 40)
+	ResourceRecordBool := isResourceRecordCountBelowLimitPerChangeSet(cs, 40)
 	require.Equal(t, true, ResourceRecordBool)
 
-	ResourceRecordBool = doesResourceRecordCountExceedLimitPerChangeSet(cs, 30)
+	ResourceRecordBool = isResourceRecordCountBelowLimitPerChangeSet(cs, 30)
 	require.Equal(t, true, ResourceRecordBool)
 
-	ResourceRecordBool = doesResourceRecordCountExceedLimitPerChangeSet(cs, 20)
+	ResourceRecordBool = isResourceRecordCountBelowLimitPerChangeSet(cs, 20)
 	require.Equal(t, false, ResourceRecordBool)
 }
 


### PR DESCRIPTION
There is 1000 limit on the total number of Resource Record elements per request [Quotas - Amazon Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html). This PR adds logic to limit the number of ResourceRecord elements per Change Batch (which is sent in a request). We set the limit to 500 to account for UPSERT requests per change 